### PR TITLE
Add Slalom Build capability to capabilities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -102,6 +102,16 @@ capabilities = {
         "capacity": 20,
         "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
     }
+    ,
+    "Slalom Build": {
+        "description": "Product development, design thinking, agile delivery, and digital innovation.",
+        "practice_area": "Technology",
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+        "certifications": ["Product Management", "Agile certifications"],
+        "industry_verticals": ["Consumer Products", "Fintech", "Healthtech"],
+        "capacity": 40,
+        "consultants": []
+    }
 }
 
 


### PR DESCRIPTION
This pull request adds the Slalom Build capability to the in-memory capabilities dictionary, including skill levels, certifications, industry verticals, and capacity planning as described in the enhancement request.